### PR TITLE
Remove pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "https://github.com/Djaler/vue-promise-dialogs"
   },
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",


### PR DESCRIPTION
I don't see a reason to require every package depending on this one to use pnpm.

Feel free to close this if there's a reason to force pnpm. But if that would be the case: adjust the README (it uses `npm install`).